### PR TITLE
Tags always in decreasing order of specificity

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This pattern is often used for tagging containers.
 
 ## Example output
 
-The GitHub action's only output is named `tags` and is a JSON formatted list. See the example workflow below for details on how to convert the JSON formatted list to something else.
+The GitHub action's only output is named `tags` and is a JSON formatted list. See the example workflow below for details on how to convert the JSON formatted list to something else. Tags will always be in decreasing order of specificity.
 
 | Pushed reference | GitHub repo tags | `tags` output                        | Comment                                                                       |
 | ---------------- | ---------------- | ------------------------------------ | ----------------------------------------------------------------------------- |


### PR DESCRIPTION
Making this part of the public API means the ordering can be relied upon in downstream images that may need to reference one of the parent tags.